### PR TITLE
use explicit import list for Data.Foldable

### DIFF
--- a/Data/PQueue/Internals.hs
+++ b/Data/PQueue/Internals.hs
@@ -33,7 +33,7 @@ module Data.PQueue.Internals (
 import Control.DeepSeq
 
 import Data.Functor
-import Data.Foldable (Foldable (..))
+import Data.Foldable (Foldable (foldr, foldl))
 import Data.Monoid (Monoid (..))
 import qualified Data.PQueue.Prio.Internals as Prio
 

--- a/Data/PQueue/Max.hs
+++ b/Data/PQueue/Max.hs
@@ -86,7 +86,7 @@ import Control.DeepSeq
 
 import Data.Monoid
 import Data.Maybe hiding (mapMaybe)
-import Data.Foldable hiding (toList)
+import Data.Foldable (Foldable(foldl, foldr))
 import Data.Traversable
 import Data.Ord hiding (Down)
 

--- a/Data/PQueue/Min.hs
+++ b/Data/PQueue/Min.hs
@@ -88,7 +88,7 @@ import Control.Applicative.Identity
 
 import Data.Monoid
 import Data.Maybe hiding (mapMaybe)
-import Data.Foldable hiding (toList)
+import Data.Foldable (Foldable(foldl, foldl', foldr))
 import Data.Traversable
 
 import qualified Data.List as List

--- a/Data/PQueue/Prio/Max.hs
+++ b/Data/PQueue/Prio/Max.hs
@@ -118,7 +118,7 @@ import Control.Applicative hiding (empty)
 import Control.Arrow
 import Data.Monoid
 import qualified Data.List as List
-import Data.Foldable hiding (toList)
+import Data.Foldable (Foldable(foldl, foldr))
 import Data.Traversable
 import Data.Maybe hiding (mapMaybe)
 import Data.PQueue.Prio.Max.Internals

--- a/Data/PQueue/Prio/Min.hs
+++ b/Data/PQueue/Prio/Min.hs
@@ -117,7 +117,7 @@ module Data.PQueue.Prio.Min (
 import Control.Applicative (Applicative (..), (<$>))
 import Data.Monoid 
 import qualified Data.List as List
-import Data.Foldable hiding (toList)
+import Data.Foldable (Foldable(foldl, foldl', foldr))
 import Data.Traversable
 import Data.Maybe (fromMaybe)
 


### PR DESCRIPTION
In base 4.8, `Data.Foldable` exports `null`. This causes conflicts in a few modules. I have change the imports of `Data.Foldable` to list only those functions that are actually used.
